### PR TITLE
feat: 添加 GitHub Actions 工作流以构建 MicroPython ESP32 固件，支持用户 C 模块

### DIFF
--- a/.github/workflows/build-micropython-esp32.yml
+++ b/.github/workflows/build-micropython-esp32.yml
@@ -1,0 +1,137 @@
+name: Build MicroPython ESP32 Firmware with User C Module
+
+on:
+  push:
+    branches: [ main, master ] # Adjust as needed
+  pull_request:
+    branches: [ main, master ] # Adjust as needed
+  workflow_dispatch: # Allows manual triggering
+
+env:
+  # --- USER CONFIGURABLE ---
+  # Relative path from the root of your repository to your User C Module directory
+  # This directory should contain your module's .c files and micropython.mk
+  USER_C_MODULE_PATH: "src/my_c_module" # Example: "my_module" or "modules/my_feature"
+
+  # Optional: Specify a MicroPython version (tag or branch) to checkout
+  # If empty, it will use the latest from micropython/micropython master
+  MPY_VERSION: "v1.22.2" # Example: "v1.20.0", "master"
+
+  # ESP-IDF Docker image version
+  ESP_IDF_VERSION: "v5.1" # Or "v4.4", "latest", etc.
+  # --- END USER CONFIGURABLE ---
+
+jobs:
+  build_firmware:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Continue building other targets even if one fails
+      matrix:
+        # Define your target ESP32 boards here
+        # These should correspond to the BOARD names in micropython/ports/esp32/boards
+        target:
+          - ESP32_GENERIC
+          - ESP32_S2_GENERIC
+          - ESP32_S3_GENERIC
+          - ESP32_C3_GENERIC
+        # You can add more specific boards like:
+        # - LOLIN_S2_MINI
+        # - UM_FEATHERS2
+        # - ESP32_CAM
+        # - ESP32_GENERIC_C3_USB   (for C3 with native USB)
+        # - ESP32_GENERIC_S3_SPIRAM_OCT (for S3 with Octal SPIRAM)
+
+    container:
+      image: espressif/esp-idf:${{ env.ESP_IDF_VERSION }}
+
+    steps:
+      - name: Checkout Your Repository (with User C Module)
+        uses: actions/checkout@v4
+        with:
+          path: main_project # Checkout your project to a specific subdirectory
+
+      - name: Clone MicroPython
+        uses: actions/checkout@v4
+        with:
+          repository: micropython/micropython
+          path: micropython # Clone MicroPython to its own subdirectory
+          ref: ${{ env.MPY_VERSION }} # Use specified version or latest if env.MPY_VERSION is empty
+          submodules: 'recursive' # Fetch submodules like libffi if needed by MicroPython
+
+      - name: Set up ESP-IDF environment (if needed by container entrypoint)
+        # The espressif/esp-idf container often sources export.sh automatically.
+        # This step is a safeguard or for custom entrypoints.
+        run: |
+          echo "Sourcing ESP-IDF environment..."
+          . $IDF_PATH/export.sh
+          echo "IDF_PATH=$IDF_PATH" >> $GITHUB_ENV
+          echo "IDF_TOOLS_PATH=$IDF_TOOLS_PATH" >> $GITHUB_ENV
+        # If you encounter issues, you might need to install tools first:
+        # run: |
+        #   $IDF_PATH/install.sh esp32,esp32s2,esp32s3,esp32c3 # Or list specific chips
+        #   . $IDF_PATH/export.sh
+        #   echo "IDF_PATH=$IDF_PATH" >> $GITHUB_ENV
+        #   echo "IDF_TOOLS_PATH=$IDF_TOOLS_PATH" >> $GITHUB_ENV
+
+
+      - name: Build mpy-cross
+        working-directory: micropython/mpy-cross
+        run: |
+          echo "Building mpy-cross..."
+          make -j$(nproc)
+
+      - name: Build Firmware for ${{ matrix.target }}
+        working-directory: micropython/ports/esp32
+        env:
+          # Path to User C Modules, relative from micropython/ports/esp32
+          # GITHUB_WORKSPACE is the root of the checkout area
+          # So, ../../main_project points to your project root
+          USER_C_MODULES_DIR: "../../../main_project/${{ env.USER_C_MODULE_PATH }}"
+        run: |
+          echo "Building firmware for ${{ matrix.target }}"
+          echo "User C Module directory: ${USER_C_MODULES_DIR}"
+
+          # Check if the user C module directory exists
+          if [ ! -d "${USER_C_MODULES_DIR}" ]; then
+            echo "Error: User C module directory '${USER_C_MODULES_DIR}' not found."
+            echo "Please check the USER_C_MODULE_PATH environment variable in your workflow."
+            ls -R ../../../main_project # List contents of main_project for debugging
+            exit 1
+          fi
+
+          # Clean previous build (important if switching boards or configurations)
+          make BOARD=${{ matrix.target }} USER_C_MODULES="${USER_C_MODULES_DIR}" FROZEN_MANIFEST="" clean
+
+          # Build submodules (like tinyusb)
+          make BOARD=${{ matrix.target }} USER_C_MODULES="${USER_C_MODULES_DIR}" FROZEN_MANIFEST="" -j$(nproc) submodules
+
+          # Build the firmware
+          make BOARD=${{ matrix.target }} USER_C_MODULES="${USER_C_MODULES_DIR}" FROZEN_MANIFEST="" -j$(nproc)
+
+      - name: Prepare Artifacts for ${{ matrix.target }}
+        id: prep_artifacts
+        run: |
+          FIRMWARE_DIR="micropython/ports/esp32/build-${{ matrix.target }}"
+          ARTIFACT_NAME="firmware-${{ matrix.target }}"
+          echo "Firmware directory: ${FIRMWARE_DIR}"
+          ls -lh "${FIRMWARE_DIR}"
+          ls -lh "${FIRMWARE_DIR}/bootloader" # bootloader.bin is in a subfolder
+
+          # Create a temporary directory for artifacts to ensure clean structure
+          mkdir -p "artifact_temp/${ARTIFACT_NAME}"
+          cp "${FIRMWARE_DIR}/firmware.bin" "artifact_temp/${ARTIFACT_NAME}/"
+          cp "${FIRMWARE_DIR}/partitions.bin" "artifact_temp/${ARTIFACT_NAME}/"
+          cp "${FIRMWARE_DIR}/bootloader/bootloader.bin" "artifact_temp/${ARTIFACT_NAME}/"
+          # Optional: include .map and .elf files for debugging
+          if [ -f "${FIRMWARE_DIR}/micropython.map" ]; then cp "${FIRMWARE_DIR}/micropython.map" "artifact_temp/${ARTIFACT_NAME}/"; fi
+          if [ -f "${FIRMWARE_DIR}/micropython.elf" ]; then cp "${FIRMWARE_DIR}/micropython.elf" "artifact_temp/${ARTIFACT_NAME}/"; fi
+
+          echo "::set-output name=artifact_path::artifact_temp/${ARTIFACT_NAME}"
+          echo "::set-output name=artifact_name::${ARTIFACT_NAME}"
+
+      - name: Upload Firmware Artifact for ${{ matrix.target }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.prep_artifacts.outputs.artifact_name }}
+          path: ${{ steps.prep_artifacts.outputs.artifact_path }}
+          if-no-files-found: error # Fail the workflow if firmware files are not found


### PR DESCRIPTION
Okay, here's a GitHub Action workflow that builds a MicroPython User C module using an ESP-IDF Docker image and compiles firmware for multiple ESP32 targets.

**Assumptions:**

1.  Your User C Module code is in your GitHub repository (e.g., in a directory like `my_c_module`).
2.  Your User C Module has a `micropython.mk` file.
3.  You want to clone MicroPython fresh for each build (this ensures you're using a specific or latest version).
4.  The firmware output typically includes `firmware.bin`, `partitions.bin`, and `bootloader.bin`.

**Workflow File (`.github/workflows/build-micropython-esp32.yml`):**

```yaml
name: Build MicroPython ESP32 Firmware with User C Module

on:
  push:
    branches: [ main, master ] # Adjust as needed
  pull_request:
    branches: [ main, master ] # Adjust as needed
  workflow_dispatch: # Allows manual triggering

env:
  # --- USER CONFIGURABLE ---
  # Relative path from the root of your repository to your User C Module directory
  # This directory should contain your module's .c files and micropython.mk
  USER_C_MODULE_PATH: "src/my_c_module" # Example: "my_module" or "modules/my_feature"

  # Optional: Specify a MicroPython version (tag or branch) to checkout
  # If empty, it will use the latest from micropython/micropython master
  MPY_VERSION: "v1.22.2" # Example: "v1.20.0", "master"

  # ESP-IDF Docker image version
  ESP_IDF_VERSION: "v5.1" # Or "v4.4", "latest", etc.
  # --- END USER CONFIGURABLE ---

jobs:
  build_firmware:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false # Continue building other targets even if one fails
      matrix:
        # Define your target ESP32 boards here
        # These should correspond to the BOARD names in micropython/ports/esp32/boards
        target:
          - ESP32_GENERIC
          - ESP32_S2_GENERIC
          - ESP32_S3_GENERIC
          - ESP32_C3_GENERIC
        # You can add more specific boards like:
        # - LOLIN_S2_MINI
        # - UM_FEATHERS2
        # - ESP32_CAM
        # - ESP32_GENERIC_C3_USB   (for C3 with native USB)
        # - ESP32_GENERIC_S3_SPIRAM_OCT (for S3 with Octal SPIRAM)

    container:
      image: espressif/esp-idf:${{ env.ESP_IDF_VERSION }}

    steps:
      - name: Checkout Your Repository (with User C Module)
        uses: actions/checkout@v4
        with:
          path: main_project # Checkout your project to a specific subdirectory

      - name: Clone MicroPython
        uses: actions/checkout@v4
        with:
          repository: micropython/micropython
          path: micropython # Clone MicroPython to its own subdirectory
          ref: ${{ env.MPY_VERSION }} # Use specified version or latest if env.MPY_VERSION is empty
          submodules: 'recursive' # Fetch submodules like libffi if needed by MicroPython

      - name: Set up ESP-IDF environment (if needed by container entrypoint)
        # The espressif/esp-idf container often sources export.sh automatically.
        # This step is a safeguard or for custom entrypoints.
        run: |
          echo "Sourcing ESP-IDF environment..."
          . $IDF_PATH/export.sh
          echo "IDF_PATH=$IDF_PATH" >> $GITHUB_ENV
          echo "IDF_TOOLS_PATH=$IDF_TOOLS_PATH" >> $GITHUB_ENV
        # If you encounter issues, you might need to install tools first:
        # run: |
        #   $IDF_PATH/install.sh esp32,esp32s2,esp32s3,esp32c3 # Or list specific chips
        #   . $IDF_PATH/export.sh
        #   echo "IDF_PATH=$IDF_PATH" >> $GITHUB_ENV
        #   echo "IDF_TOOLS_PATH=$IDF_TOOLS_PATH" >> $GITHUB_ENV


      - name: Build mpy-cross
        working-directory: micropython/mpy-cross
        run: |
          echo "Building mpy-cross..."
          make -j$(nproc)

      - name: Build Firmware for ${{ matrix.target }}
        working-directory: micropython/ports/esp32
        env:
          # Path to User C Modules, relative from micropython/ports/esp32
          # GITHUB_WORKSPACE is the root of the checkout area
          # So, ../../main_project points to your project root
          USER_C_MODULES_DIR: "../../../main_project/${{ env.USER_C_MODULE_PATH }}"
        run: |
          echo "Building firmware for ${{ matrix.target }}"
          echo "User C Module directory: ${USER_C_MODULES_DIR}"

          # Check if the user C module directory exists
          if [ ! -d "${USER_C_MODULES_DIR}" ]; then
            echo "Error: User C module directory '${USER_C_MODULES_DIR}' not found."
            echo "Please check the USER_C_MODULE_PATH environment variable in your workflow."
            ls -R ../../../main_project # List contents of main_project for debugging
            exit 1
          fi

          # Clean previous build (important if switching boards or configurations)
          make BOARD=${{ matrix.target }} USER_C_MODULES="${USER_C_MODULES_DIR}" FROZEN_MANIFEST="" clean

          # Build submodules (like tinyusb)
          make BOARD=${{ matrix.target }} USER_C_MODULES="${USER_C_MODULES_DIR}" FROZEN_MANIFEST="" -j$(nproc) submodules

          # Build the firmware
          make BOARD=${{ matrix.target }} USER_C_MODULES="${USER_C_MODULES_DIR}" FROZEN_MANIFEST="" -j$(nproc)

      - name: Prepare Artifacts for ${{ matrix.target }}
        id: prep_artifacts
        run: |
          FIRMWARE_DIR="micropython/ports/esp32/build-${{ matrix.target }}"
          ARTIFACT_NAME="firmware-${{ matrix.target }}"
          echo "Firmware directory: ${FIRMWARE_DIR}"
          ls -lh "${FIRMWARE_DIR}"
          ls -lh "${FIRMWARE_DIR}/bootloader" # bootloader.bin is in a subfolder

          # Create a temporary directory for artifacts to ensure clean structure
          mkdir -p "artifact_temp/${ARTIFACT_NAME}"
          cp "${FIRMWARE_DIR}/firmware.bin" "artifact_temp/${ARTIFACT_NAME}/"
          cp "${FIRMWARE_DIR}/partitions.bin" "artifact_temp/${ARTIFACT_NAME}/"
          cp "${FIRMWARE_DIR}/bootloader/bootloader.bin" "artifact_temp/${ARTIFACT_NAME}/"
          # Optional: include .map and .elf files for debugging
          if [ -f "${FIRMWARE_DIR}/micropython.map" ]; then cp "${FIRMWARE_DIR}/micropython.map" "artifact_temp/${ARTIFACT_NAME}/"; fi
          if [ -f "${FIRMWARE_DIR}/micropython.elf" ]; then cp "${FIRMWARE_DIR}/micropython.elf" "artifact_temp/${ARTIFACT_NAME}/"; fi

          echo "::set-output name=artifact_path::artifact_temp/${ARTIFACT_NAME}"
          echo "::set-output name=artifact_name::${ARTIFACT_NAME}"

      - name: Upload Firmware Artifact for ${{ matrix.target }}
        uses: actions/upload-artifact@v3
        with:
          name: ${{ steps.prep_artifacts.outputs.artifact_name }}
          path: ${{ steps.prep_artifacts.outputs.artifact_path }}
          if-no-files-found: error # Fail the workflow if firmware files are not found
```

**Explanation and How to Use:**

1.  **Save the File:** Create a file named `.github/workflows/build-micropython-esp32.yml` in your repository.
2.  **Configure `env` Variables (IMPORTANT):**
    *   `USER_C_MODULE_PATH`:
        *   This is the **most critical** setting.
        *   It's the path to your User C Module directory, **relative to the root of your repository**.
        *   For example, if your module `myexample.c` and `micropython.mk` are in `my_repo_root/src/my_module/`, then set `USER_C_MODULE_PATH: "src/my_module"`.
    *   `MPY_VERSION`:
        *   Set this to a specific MicroPython tag (e.g., `v1.22.2`, `v1.21.0`) or a branch name (e.g., `master`).
        *   If left empty or commented out, it will try to use the latest `master` branch of MicroPython, which might be unstable. It's generally recommended to pin to a specific release tag.
    *   `ESP_IDF_VERSION`:
        *   The tag for the `espressif/esp-idf` Docker image. Common choices are `v5.1`, `v5.0`, `v4.4`, or `latest`. Using a specific version is recommended for reproducibility.
3.  **Configure `matrix.target`:**
    *   In the `strategy.matrix.target` list, specify the `BOARD` names you want to compile for.
    *   These names correspond to the board definition directories found in `micropython/ports/esp32/boards/`.
    *   `ESP32_GENERIC`, `ESP32_S2_GENERIC`, `ESP32_S3_GENERIC`, `ESP32_C3_GENERIC` are good starting points for generic chips.
4.  **User C Module Structure:**
    *   Your User C Module directory (e.g., `src/my_c_module`) must contain:
        *   Your C source files (e.g., `my_module_code.c`).
        *   A `micropython.mk` file that tells the MicroPython build system how to compile your module. A minimal `micropython.mk` might look like:

        ```makefile
        # src/my_c_module/micropython.mk
        MY_MODULE_DIR := $(USER_C_MODULE_DIR)
        # Add all C files to SRC_USERMOD
        SRC_USERMOD += $(MY_MODULE_DIR)/my_module_code.c
        # You can add more .c files if your module has multiple
        # SRC_USERMOD += $(MY_MODULE_DIR)/another_file.c

        # Optional: Add include paths if needed
        # CFLAGS_USERMOD += -I$(MY_MODULE_DIR)/include
        ```
5.  **Push to GitHub:** Commit and push this workflow file to your repository. The action will trigger on pushes or pull requests to the specified branches. You can also trigger it manually from the "Actions" tab in your GitHub repository if `workflow_dispatch` is enabled.
6.  **Artifacts:** After a successful run, you'll find `.zip` files in the "Artifacts" section of the GitHub Actions run. Each zip will contain `firmware.bin`, `partitions.bin`, and `bootloader.bin` for the corresponding target.

**Troubleshooting:**

*   **Path Issues:** The most common issue is an incorrect `USER_C_MODULE_PATH` or problems with how `USER_C_MODULES` is resolved inside the `make` command. The `ls -R ../../../main_project` in the error check can help debug this.
*   **ESP-IDF Version vs. MicroPython Version:** Ensure the ESP-IDF version used by the Docker image is compatible with the MicroPython version and its ESP32 port.
*   **Missing Tools in Docker:** The `espressif/esp-idf` images are generally well-equipped. If you see errors about missing compilers (`xtensa-esp32-elf-gcc`, `riscv32-esp-elf-gcc`, etc.) or `idf.py`, you might need to uncomment and adjust the `$IDF_PATH/install.sh` line in the "Set up ESP-IDF environment" step, or try a different `ESP_IDF_VERSION`.
*   **Build Errors in User C Module:** Standard C compilation errors will appear in the logs.
*   **`FROZEN_MANIFEST=""`:** This is used to prevent MicroPython from trying to freeze Python scripts if you don't have a manifest file. If you *do* use frozen scripts/modules, adjust this accordingly.